### PR TITLE
note PeriodicalLog dependency on Java 6 and update version in Maven and Ivy samples

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,9 @@
 * You can now shut up the PeriodicalLog logging by simply setting the slf4jLogName
   to an empty string.
 
+* PeriodicalLog now requires Java 6 for j.u.c.LinkedBlockingDeque.  Speed4j can
+  only be used on Java 5 VM if PeriodicalLog is not used.
+
 0.9
 ===
 

--- a/README
+++ b/README
@@ -20,12 +20,12 @@ Or, you can put this into your pom.xml:
 <dependency>
     <groupId>com.ecyrd.speed4j</groupId>
     <artifactId>speed4j</artifactId>
-    <version>0.3</version>
+    <version>0.11</version>
 </dependency>
 
 Or, if you like Apache Ivy more, use this:
 
-<dependency org="com.ecyrd.speed4j" name="speed4j" rev="0.3"/>
+<dependency org="com.ecyrd.speed4j" name="speed4j" rev="0.11"/>
 
 
 

--- a/README
+++ b/README
@@ -147,6 +147,8 @@ something that looks like this:
 (The 95th means the 95th percentile, i.e. 95% of all calls stayed under this limit.  This is very useful
 for figuring out which methods have wildy varying performance.)
 
+PeriodicalLog requires Java 6.
+
 PROGRAMMATIC CONFIGURATION
 ==========================
 


### PR DESCRIPTION
Janne,

While using speed4j with Java 5, I noticed PeriodicalLog requires Java 6 for
LinkedBlockingDeque as of
jalkanen/speed4j@9abfa6dadd373479159cbefe7e63fd67f6858534 .

This pull request notes the dependency in the README and NEWS file and
also updates the speed4j version from 0.3 to 0.11 in the Maven and Ivy
samples.

--Brad
