### PR TITLE
Log class names should be fully qualified.

### DIFF
--- a/examples/speed4j.properties
+++ b/examples/speed4j.properties
@@ -13,7 +13,7 @@
 #  Then all stopwatches returned by myFactory.getStopWatch() will log to myLogger.
 #
 
-speed4j.myLogger=PeriodicalLog
+speed4j.myLogger=com.ecyrd.speed4j.log.PeriodicalLog
 speed4j.myLogger.period=60
 speed4j.myLogger.jmx=myitem
 speed4j.myLogger.enable=true
@@ -24,5 +24,5 @@ speed4j.myLogger.slf4jLogname=com.ecyrd.log
 #  simply log to the "com.ecyrd.anotherlog" SLF4J logger using
 #  DEBUG level.
 #
-speed4j.yourLogger=Slf4jLog
+speed4j.yourLogger=com.ecyrd.speed4j.log.Slf4jLog
 speed4j.yourLogger.slf4jLogname=com.ecyrd.anotherlog


### PR DESCRIPTION
Minor fix in `examples/speed4j.properties`.
