### PR TITLE
remove String.isEmpty() for Java 5 compatibility

### DIFF
--- a/src/main/java/com/ecyrd/speed4j/log/Slf4jLog.java
+++ b/src/main/java/com/ecyrd/speed4j/log/Slf4jLog.java
@@ -37,7 +37,8 @@ public class Slf4jLog extends Log
      */
     public void setSlf4jLogname(String logName)
     {
-        if( logName.isEmpty() ) 
+        // use length() == 0 instead of isEmpty() for Java 5 compatibility
+        if( logName.length() == 0 )
         {
             m_log = null;
         }


### PR DESCRIPTION
Was testing Slf4jLog under Java 5 but the String.isEmpty() prevented the Log
from being initialized.  This appears to be the only Java 6 code outside
PeriodicalLog so it seemed worthwhile to change in order to keep the core
of speed4j working on Java 5.
